### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/projects/financial_use_cases/README.md
+++ b/projects/financial_use_cases/README.md
@@ -14,7 +14,7 @@ This repository contains example use cases for [Autogen](https://github.com/micr
 2. Install the required package:
 
    ```bash
-   pip install pyautogen
+   pip install ag2
    ```
 
 ## Available Use Cases

--- a/projects/financial_use_cases/algorithmic_trading/README.md
+++ b/projects/financial_use_cases/algorithmic_trading/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/compliance_monitoring/README.md
+++ b/projects/financial_use_cases/compliance_monitoring/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/credit_risk_assessment/README.md
+++ b/projects/financial_use_cases/credit_risk_assessment/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/customer_support/README.md
+++ b/projects/financial_use_cases/customer_support/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/data_extraction/README.md
+++ b/projects/financial_use_cases/data_extraction/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/fraud_detection/README.md
+++ b/projects/financial_use_cases/fraud_detection/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/loan_underwriting/README.md
+++ b/projects/financial_use_cases/loan_underwriting/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/market_sentiment_analysis/README.md
+++ b/projects/financial_use_cases/market_sentiment_analysis/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/portfolio_optimization/README.md
+++ b/projects/financial_use_cases/portfolio_optimization/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/financial_use_cases/regulatory_reporting/README.md
+++ b/projects/financial_use_cases/regulatory_reporting/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/README.md
+++ b/projects/research_use_cases/README.md
@@ -14,7 +14,7 @@ ollama run llama2
 2. Install the required package:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 ## Available Use Cases

--- a/projects/research_use_cases/citation_management/README.md
+++ b/projects/research_use_cases/citation_management/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/data_collection/README.md
+++ b/projects/research_use_cases/data_collection/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/experiment_design/README.md
+++ b/projects/research_use_cases/experiment_design/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/grant_proposal_writing/README.md
+++ b/projects/research_use_cases/grant_proposal_writing/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/hypothesis_generation/README.md
+++ b/projects/research_use_cases/hypothesis_generation/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/literature_review_automation/README.md
+++ b/projects/research_use_cases/literature_review_automation/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/paper_summary/README.md
+++ b/projects/research_use_cases/paper_summary/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/research_collaboration/README.md
+++ b/projects/research_use_cases/research_collaboration/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/statistical_modeling/README.md
+++ b/projects/research_use_cases/statistical_modeling/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:

--- a/projects/research_use_cases/survey_analysis/README.md
+++ b/projects/research_use_cases/survey_analysis/README.md
@@ -16,7 +16,7 @@ ollama run llama2
 2. Install dependencies:
 
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 3. Execute the example:


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
